### PR TITLE
Add new module react-app-example

### DIFF
--- a/lib/modules/mods.js
+++ b/lib/modules/mods.js
@@ -42,6 +42,7 @@ Mods.prototype.pre_initialize = function pre_initialize() {
   this.mods.push(require('./mods/faucet/faucet')(this.app));
   this.mods.push(require('./mods/registry/registry')(this.app));
   this.mods.push(require('./mods/reddit/reddit')(this.app));
+  this.mods.push(require('./mods/react/build/index')(this.app));
   this.mods.push(require('./mods/remix/remix')(this.app));
   this.mods.push(require('./mods/secret/secret')(this.app));
   this.mods.push(require('./mods/money/money')(this.app));

--- a/lib/modules/mods/react/.babelrc
+++ b/lib/modules/mods/react/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets":[
+        "env", "react"
+    ]
+}
+

--- a/lib/modules/mods/react/.gitignore
+++ b/lib/modules/mods/react/.gitignore
@@ -1,0 +1,4 @@
+build
+node_modules
+coverage
+

--- a/lib/modules/mods/react/package.json
+++ b/lib/modules/mods/react/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "react-app-example",
+  "version": "1.0.0",
+  "description": "An example of building React apps on Saito",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "babel ./src -d build",
+    "build:watch": "babel ./src -d build --watch",
+    "build:client": "webpack --config ./webpack.config.js",
+    "build:watch:client": "webpack --config ./webpack.config.js/ --watch",
+    "build:prod": "npm run build && npm run build:client"
+  },
+  "keywords": [
+    "React",
+    "JavaScript",
+    "Webdev"
+  ],
+  "author": "Stephen Peterkins",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.8.2",
+    "webpack-cli": "^2.1.3"
+  }
+}

--- a/lib/modules/mods/react/src/app/components/App.js
+++ b/lib/modules/mods/react/src/app/components/App.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+
+class App extends Component {
+  render(){
+    return (
+      <div className="app">
+        <div className="header">
+          <div className="spacing">
+            <h3>ReactApp</h3>
+          </div>
+        </div>
+        <div className="content">
+          <div className="spacing">
+            <h1>Greetings from React!</h1>
+          </div>
+        </div>
+        <div className="footer">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg"
+              style={{ height: '4em', justifySelf: 'center'}}/>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default App

--- a/lib/modules/mods/react/src/app/index.js
+++ b/lib/modules/mods/react/src/app/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import App from './components/App.js';
+
+ReactDOM.render(
+    <App/>,
+    document.getElementById('root')
+);

--- a/lib/modules/mods/react/src/index.js
+++ b/lib/modules/mods/react/src/index.js
@@ -1,0 +1,82 @@
+const path = require('path');
+var saito = require('../../../../saito');
+var ModTemplate = require('../../../template');
+var util = require('util');
+
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import App from './app/components/App'
+
+import renderFullPage from './server/renderFullPage'
+
+//////////////////
+// CONSTRUCTOR  //
+//////////////////
+function ReactApp(app) {
+
+  if (!(this instanceof ReactApp)) { return new ReactApp(app); }
+
+  ReactApp.super_.call(this);
+
+  this.app                = app;
+
+  this.name               = "ReactApp";
+  this.browser_active     = 0;
+  this.handlesReactApp    = 1;
+  this.ReactAppAppName    = "ReactApp";
+
+  return this;
+
+}
+module.exports = ReactApp;
+util.inherits(ReactApp, ModTemplate);
+
+
+
+
+ReactApp.prototype.initialize = function initialize(app) {
+
+  if (app.BROWSER == 0) { return; }
+
+  // remove us if mobile client is running
+  if ($('#ReactApp_browser_active').length == 0) {
+    for (var t = app.modules.mods.length-1; t >= 0; t--) {
+      if (app.modules.mods[t].name == "ReactAppMobile") {
+        app.modules.mods.splice(t, 1);
+      }
+    }
+  }
+
+}
+
+
+/////////////////////////
+// Handle Web Requests //
+/////////////////////////
+ReactApp.prototype.webServer = function webServer(app, expressapp) {
+
+  const html = renderToString(<App/>)
+
+  expressapp.get('/react-app/', function (req, res) {
+    res.status(200)
+    res.send(renderFullPage(html));
+    return;
+  });
+  expressapp.get('/react-app/style.css', function (req, res) {
+    res.sendFile(__dirname + '/style/style.css');
+    return;
+  });
+  expressapp.get('/react-app/bundle.js', function (req, res) {
+    res.sendFile(__dirname + '/bundle.js');
+    return;
+  });
+}
+
+ReactApp.prototype.isPublicKey = function isPublicKey(publickey) {
+  if (publickey.length == 44 || publickey.length == 45) {
+    if (publickey.indexOf("@") > 0) {} else {
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/lib/modules/mods/react/src/server/renderFullPage.js
+++ b/lib/modules/mods/react/src/server/renderFullPage.js
@@ -1,0 +1,16 @@
+export default function renderFullPage(html) {
+    return `
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>React App</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <link rel="stylesheet" type="text/css" href="/react-app/style.css" />
+        </head>
+        <body>
+            <div id="root">${html}</div>
+            <script src="/react-app/bundle.js"></script>
+        </body>
+        </html>
+    `
+};

--- a/lib/modules/mods/react/src/style/style.css
+++ b/lib/modules/mods/react/src/style/style.css
@@ -1,0 +1,63 @@
+html {
+    font-family: sans-serif;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+body {
+    height: 100%;
+    margin: 0;
+}
+
+#root {
+    min-height: 100%;
+}
+
+.app {
+    display: grid;
+    grid-gap: 1.2em;
+    grid-template-columns: 1fr 4fr 1fr; /*120px auto 120px;*/
+    grid-template-rows: auto 1fr auto;
+    width: 100vw;
+    height: 100vh;
+    grid-template-areas:
+    "header  header  header"
+    "content content content"
+    "footer  footer  footer";
+}
+
+.spacing {
+    display: inherit;
+    padding-left: 1.5em;
+    padding-right: 1.5em;
+}
+
+.header {
+    grid-area: header;
+}
+
+.content {
+    grid-area: content;
+}
+
+.footer {
+    display: inherit;
+    grid-area: footer;
+    background-color: rgba(15, 19, 25, 0.95);
+    color: #fff;
+}
+
+@media only screen and (max-width: 600px) {
+    .app {
+        display: grid;
+        height: 100vh;
+        grid-gap: 1em;
+        grid-template-rows: auto 1fr auto;
+        grid-template-areas:
+        "header"
+        "content"
+        "footer"
+    }
+}

--- a/lib/modules/mods/react/webpack.config.js
+++ b/lib/modules/mods/react/webpack.config.js
@@ -4,7 +4,6 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
     devtool: 'inline-source-app',
-    // context: path.resolve(__dirname, '..'),
     entry:  ['./build/app/index.js'],
     output: {
         path: path.join(__dirname, 'build'),

--- a/lib/modules/mods/react/webpack.config.js
+++ b/lib/modules/mods/react/webpack.config.js
@@ -1,0 +1,33 @@
+var path = require('path');
+var webpack = require('webpack');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    devtool: 'inline-source-app',
+    // context: path.resolve(__dirname, '..'),
+    entry:  ['./build/app/index.js'],
+    output: {
+        path: path.join(__dirname, 'build'),
+        filename: 'bundle.js',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: ['style-loader', 'css-loader']
+            },
+            {
+                test: /\.(js|jsx)$/,
+                loader: 'babel-loader',
+                include: path.join(__dirname, 'app'),
+                exclude: /node_modules/,
+                query: {
+                    presets: ['es2015', 'react']
+                }
+            }
+        ]
+    },
+    plugins: [
+        new HtmlWebpackPlugin()
+    ]
+}

--- a/options
+++ b/options
@@ -1,1 +1,0 @@
-{"server":{"host":"localhost","port":12101,"publickey":""},"wallet":{"balance":0,"privateKey":"2942ff64a69a623531ee3eb73a1214041cc6e7690b984d5aa4ce81bf3954a8ce","publicKey":"cDmndussZA9qWK1F5stJc3MQcgA5Sxi6b7TxjgaGXaXQ","identifier":"","utxi":[],"utxo":[],"version":1.6},"keys":{},"modules":[]}

--- a/options
+++ b/options
@@ -1,0 +1,1 @@
+{"server":{"host":"localhost","port":12101,"publickey":""},"wallet":{"balance":0,"privateKey":"2942ff64a69a623531ee3eb73a1214041cc6e7690b984d5aa4ce81bf3954a8ce","publicKey":"cDmndussZA9qWK1F5stJc3MQcgA5Sxi6b7TxjgaGXaXQ","identifier":"","utxi":[],"utxo":[],"version":1.6},"keys":{},"modules":[]}


### PR DESCRIPTION
This PR adds a new module that serves as an example of one way to build React apps on the Saito network. This is the first iteration, to get it running make sure to:
- run the "npm run build:prod" script to have babel convert the ES6 code to vanilla javascript
- copy and paste the `src/style` directory into the `build` directory afterwards

This is a very basic isomorphic React app. In the future, I'd like to find a way to package the CSS automatically through [webpack-isomorphic-tools](https://github.com/catamphetamine/webpack-isomorphic-tools) and also convert ES6 on the fly rather than manual transpilation.
