### PR TITLE
fix for error tmsql undefined on chain reorg

### DIFF
--- a/lib/modules/mods/registry/registry.js
+++ b/lib/modules/mods/registry/registry.js
@@ -107,10 +107,10 @@ Registry.prototype.installModule = function installModule() {
 //          }
 //        }
 //      }
- 
+
 
       //
-      // fetch the latest DNS data from our server 
+      // fetch the latest DNS data from our server
       //
       try {
         request.get(master_url, (error, response, body) => {
@@ -123,7 +123,7 @@ Registry.prototype.installModule = function installModule() {
 	      var write_to_file = lines[m] + "\n";
               var line = lines[m].split("\t");
 
-	      if (line.length != 7) {} else {	      
+	      if (line.length != 7) {} else {
 
 	        var identifier = line[0];
 		var block_id   = line[1];
@@ -138,11 +138,11 @@ Registry.prototype.installModule = function installModule() {
 
 	     	  var msgtosign   = identifier + address + block_id + block_hash;
 	    	  var msgverifies = registry_self.app.crypt.verifyMessage(msgtosign, sig, signer);
- 
+
 		  if (msgverifies == true) {
 		    var sql = "INSERT OR IGNORE INTO mod_registry_addresses (identifier, publickey, unixtime, block_id, block_hash, signature, signer, longest_chain) VALUES ($identifier, $publickey, $unixtime, $block_id, $block_hash, $sig, $signer, $longest_chain)";
-		    var params = { 
-		      $identifier : identifier, 
+		    var params = {
+		      $identifier : identifier,
 		      $publickey : address,
 		      $unixtime : unixtime,
 		      $block_id : block_id,
@@ -291,8 +291,8 @@ console.log("1");
 
   var registry_self = app.modules.returnModule("Registry");
 
-  // browsers check to see if the name has been registered 
-  // after 1 confirmation, assuming that servers will be 
+  // browsers check to see if the name has been registered
+  // after 1 confirmation, assuming that servers will be
   // processing the request on the zeroth-confirmation
   if (conf == 0) {
     if (app.BROWSER == 1) {
@@ -306,7 +306,7 @@ console.log("1");
 	}
       });
     }
-  }  
+  }
 
 console.log("2");
 
@@ -354,7 +354,7 @@ console.log("8");
           if (row.count == 0) {
 
 	    var msgtosign   = full_identifier + tx.transaction.from[0].add + blk.block.id + blk.returnHash();
-	    var registrysig = app.crypt.signMessage(msgtosign, app.wallet.returnPrivateKey()); 
+	    var registrysig = app.crypt.signMessage(msgtosign, app.wallet.returnPrivateKey());
             var sql = "INSERT OR IGNORE INTO mod_registry_addresses (identifier, publickey, unixtime, block_id, block_hash, signature, signer, longest_chain) VALUES ($identifier, $publickey, $unixtime, $block_id, $block_hash, $sig, $signer, $longest_chain)";
             var params = { $identifier : full_identifier, $publickey : tx.transaction.from[0].add, $unixtime : tx.transaction.ts , $block_id : blk.returnId(), $block_hash : blk.returnHash(), $sig : registrysig , $signer : app.wallet.returnPublicKey(), $longest_chain : 1 };
 
@@ -372,9 +372,9 @@ console.log("HERE WE ARE!");
 console.log("9");
             registry_self.db.run(sql, params, function() {
 console.log("10");
-            
+
 	      // only main signing server needs handle this
-              if (tx.transaction.to[0].add == registry_self.publickey && registry_self.publickey == registry_self.app.wallet.returnPublicKey()) { 
+              if (tx.transaction.to[0].add == registry_self.publickey && registry_self.publickey == registry_self.app.wallet.returnPublicKey()) {
 console.log("11");
 
                 to = tx.transaction.from[0].add;
@@ -514,17 +514,15 @@ Registry.prototype.onChainReorganization  = function onChainReorganization(block
   if (lc == 0) {
     var sql    = "UPDATE mod_registry_addresses SET longest_chain = 0 WHERE block_id = $block_id AND block_hash = $block_hash";
     var params = { $block_id : block_id , $block_hash : block_hash }
-    registry_self.db.run(tmsql, params, function(err, row) {
+    registry_self.db.run(sql, params, function(err, row) {
     });
   }
 
   if (lc == 1) {
     var sql    = "UPDATE mod_registry_addresses SET longest_chain = 1 WHERE block_id = $block_id AND block_hash = $block_hash";
     var params = { $block_id : block_id , $block_hash : block_hash }
-    registry_self.db.run(tmsql, params, function(err, row) {
+    registry_self.db.run(sql, params, function(err, row) {
     });
   }
 
 }
-
-


### PR DESCRIPTION
Test

1. Create two clean nodes
1. Run node one
1. Update Node two to list node one as a peer
2. Run node two
3. Node two syncs

Problem: Node two marks block two as longest chain (though it has 3 and four.)

6. Restart two 

Error:
```
START TIME: 1526745961026
Adding block 3 -> 723f24dab46ee3715201959642c32c1f4a7c39ed6f46cb1c660ebd43eb960815 1526745796871
validate longest chain...
 ... unwind old chain
/home/richardp/projects/saito.test/two/lib/modules/mods/registry/registry.js:517
    registry_self.db.run(tmsql, params, function(err, row) {
                         ^

ReferenceError: tmsql is not defined
    at Registry.onChainReorganization (/home/richardp/projects/saito.test/two/lib/modules/mods/registry/registry.js:517:26)
    at Mods.onChainReorganization (/home/richardp/projects/saito.test/two/lib/modules/mods.js:191:20)
    at /home/richardp/projects/saito.test/two/lib/saito/storage.js:1119:32
    at Blockchain.returnBlockByHash (/home/richardp/projects/saito.test/two/lib/saito/blockchain.js:1610:9)
    at Storage.unwindChain (/home/richardp/projects/saito.test/two/lib/saito/storage.js:1110:33)
    at Storage.validateLongestChain (/home/richardp/projects/saito.test/two/lib/saito/storage.js:1400:18)
    at Blockchain.addBlockToBlockchain (/home/richardp/projects/saito.test/two/lib/saito/blockchain.js:801:22)
    at Timeout._onTimeout (/home/richardp/projects/saito.test/two/lib/saito/mempool.js:599:65)
    at ontimeout (timers.js:427:11)
    at tryOnTimeout (timers.js:289:5)
 ```